### PR TITLE
Add tests using GoAWS SQS clone

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/Admiral-Piett/goaws v0.5.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.5.2 // indirect
@@ -31,9 +32,15 @@ require (
 	github.com/aws/smithy-go v1.28.1 // indirect
 	github.com/garyburd/redigo v1.6.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/schema v1.4.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/gomega v1.27.1 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	gopkg.in/bsm/ratelimit.v1 v1.0.0-20160220154919-db14e161995a // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Admiral-Piett/goaws v0.5.4 h1:3El0So7p6dLhjf+3hFsq0TF+9TDyvC6DxqzuDNodEiM=
+github.com/Admiral-Piett/goaws v0.5.4/go.mod h1:2ARQVFxYttlY4nci4L6/QVtuEopqGd+tiiYYt4JboN4=
 github.com/VividCortex/godaemon v1.0.0 h1:aHYrScWvgaSOdAoYCdObWXLm+e1rldP9Pwb1ZvuZkQw=
 github.com/VividCortex/godaemon v1.0.0/go.mod h1:hBWe/72KbGt/lb95E+Sh9ersdYbB57Dt6CG66S1YPno=
 github.com/aws/aws-sdk-go-v2 v1.46.0 h1:1kt7m/EKcEHt5mlyyxx9cSlMddRPIKbjb6DIQsu4HPk=
@@ -55,6 +57,12 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
+github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/koron/go-valid v1.0.0 h1:0i+eszV1r1v+fx01xrK6lMte7oUaU1P5rMQ/4HSPQyI=
 github.com/koron/go-valid v1.0.0/go.mod h1:IlYKifUShurgElmG2Os/BtspVyoxZnY9T3hEQq0plk4=
@@ -64,6 +72,10 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -79,8 +91,11 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec h1:DGmKwyZwEB8dI7tbLt/I/gQuP559o/0FrAkHKlQM/Ks=
 github.com/vaughan0/go-ini v0.0.0-20130923145212-a98ad7ee00ec/go.mod h1:owBmyHYMLkxyrugmfwE/DLJyW8Ro9mkphwuVErQ0iUw=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -109,6 +124,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -141,5 +157,6 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sqsnotify2/goaws_test.go
+++ b/sqsnotify2/goaws_test.go
@@ -1,0 +1,263 @@
+package sqsnotify2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Admiral-Piett/goaws/app/models"
+	"github.com/Admiral-Piett/goaws/app/servertest"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	body, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		os.Exit(2)
+	}
+	if strings.Contains(string(body), "FAIL") {
+		os.Exit(1)
+	}
+	fmt.Printf("HELPER_OUTPUT: %s\n", string(body))
+}
+
+func setupGoAWSServer(t *testing.T) (*servertest.Server, *sqs.Client) {
+	t.Helper()
+
+	srv, err := servertest.New("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start goaws servertest: %v", err)
+	}
+
+	u, err := url.Parse(srv.URL())
+	if err != nil {
+		srv.Quit()
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+
+	models.CurrentEnvironment.Host = u.Hostname()
+	models.CurrentEnvironment.Port = u.Port()
+	models.CurrentEnvironment.Region = "us-east-1"
+
+	ctx := context.Background()
+	awsCfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion("us-east-1"),
+	)
+	if err != nil {
+		srv.Quit()
+		t.Fatalf("failed to load aws config: %v", err)
+	}
+
+	sqsClient := sqs.NewFromConfig(awsCfg, func(o *sqs.Options) {
+		o.BaseEndpoint = aws.String(srv.URL())
+	})
+
+	return srv, sqsClient
+}
+
+func TestSQSNotifyWithGoAWS(t *testing.T) {
+	os.Setenv("GO_WANT_HELPER_PROCESS", "1")
+	os.Setenv("AWS_ACCESS_KEY_ID", "mock_access_key")
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "mock_secret_key")
+	os.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	defer func() {
+		os.Unsetenv("GO_WANT_HELPER_PROCESS")
+		os.Unsetenv("AWS_ACCESS_KEY_ID")
+		os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+		os.Unsetenv("AWS_EC2_METADATA_DISABLED")
+	}()
+
+	t.Run("CreateQueue and Process Message with Succeed Policy", func(t *testing.T) {
+		srv, sqsClient := setupGoAWSServer(t)
+		defer srv.Quit()
+
+		queueName := "test-goaws-create-queue"
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		wt := int64(1)
+		cfg := NewConfig()
+		cfg.Endpoint = srv.URL()
+		cfg.Region = "us-east-1"
+		cfg.QueueName = queueName
+		cfg.CreateQueue = true
+		cfg.CmdName = os.Args[0]
+		cfg.CmdArgs = []string{"-test.run=TestHelperProcess"}
+		cfg.RemovePolicy = Succeed
+		cfg.WaitTime = &wt
+
+		sn := New(cfg)
+
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- sn.Run(runCtx, newMemoryCache(10))
+		}()
+
+		// Wait for queue creation by SQSNotify
+		var qUrl string
+		for i := 0; i < 50; i++ {
+			qUrlRes, err := sqsClient.GetQueueUrl(ctx, &sqs.GetQueueUrlInput{
+				QueueName: aws.String(queueName),
+			})
+			if err == nil && qUrlRes.QueueUrl != nil {
+				qUrl = *qUrlRes.QueueUrl
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		if qUrl == "" {
+			t.Fatalf("queue was not created in time")
+		}
+
+		// Send message to the created queue
+		_, err := sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    aws.String(qUrl),
+			MessageBody: aws.String("hello goaws succeed"),
+		})
+		if err != nil {
+			t.Fatalf("failed to send message: %v", err)
+		}
+
+		// Wait for message processing
+		time.Sleep(500 * time.Millisecond)
+
+		runCancel()
+		runErr := <-errCh
+		if runErr != nil && !errorsIsCanceled(runErr) {
+			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+	})
+
+	t.Run("Existing Queue and BeforeExecution Policy", func(t *testing.T) {
+		srv, sqsClient := setupGoAWSServer(t)
+		defer srv.Quit()
+
+		queueName := "test-goaws-before-execution"
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		createRes, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+			QueueName: aws.String(queueName),
+		})
+		if err != nil {
+			t.Fatalf("failed to create queue: %v", err)
+		}
+
+		wt := int64(1)
+		cfg := NewConfig()
+		cfg.Endpoint = srv.URL()
+		cfg.Region = "us-east-1"
+		cfg.QueueName = queueName
+		cfg.CreateQueue = false
+		cfg.CmdName = os.Args[0]
+		cfg.CmdArgs = []string{"-test.run=TestHelperProcess"}
+		cfg.RemovePolicy = BeforeExecution
+		cfg.WaitTime = &wt
+
+		sn := New(cfg)
+
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- sn.Run(runCtx, newMemoryCache(10))
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		_, err = sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    createRes.QueueUrl,
+			MessageBody: aws.String("hello goaws before execution"),
+		})
+		if err != nil {
+			t.Fatalf("failed to send message: %v", err)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		runCancel()
+		runErr := <-errCh
+		if runErr != nil && !errorsIsCanceled(runErr) {
+			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+	})
+
+	t.Run("Existing Queue and IgnoreFailure Policy", func(t *testing.T) {
+		srv, sqsClient := setupGoAWSServer(t)
+		defer srv.Quit()
+
+		queueName := "test-goaws-ignore-failure"
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		createRes, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+			QueueName: aws.String(queueName),
+		})
+		if err != nil {
+			t.Fatalf("failed to create queue: %v", err)
+		}
+
+		wt := int64(1)
+		cfg := NewConfig()
+		cfg.Endpoint = srv.URL()
+		cfg.Region = "us-east-1"
+		cfg.QueueName = queueName
+		cfg.CreateQueue = false
+		cfg.CmdName = os.Args[0]
+		cfg.CmdArgs = []string{"-test.run=TestHelperProcess"}
+		cfg.RemovePolicy = IgnoreFailure
+		cfg.WaitTime = &wt
+
+		sn := New(cfg)
+
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- sn.Run(runCtx, newMemoryCache(10))
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		_, err = sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    createRes.QueueUrl,
+			MessageBody: aws.String("FAIL - should ignore failure"),
+		})
+		if err != nil {
+			t.Fatalf("failed to send message: %v", err)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		runCancel()
+		runErr := <-errCh
+		if runErr != nil && !errorsIsCanceled(runErr) {
+			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+	})
+}
+
+func errorsIsCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "canceled") || strings.Contains(err.Error(), "context canceled")
+}

--- a/sqsnotify2/wrap_sqs.go
+++ b/sqsnotify2/wrap_sqs.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/aws/smithy-go"
 )
 
 // SQSClient defines the interface for SQS operations used by SQSNotify.
@@ -40,7 +41,15 @@ func getQueueURL(ctx context.Context, api SQSClient, queueName string, create bo
 
 func isQueueDoesNotExist(err error) bool {
 	var qne *types.QueueDoesNotExist
-	return errors.As(err, &qne)
+	if errors.As(err, &qne) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		code := apiErr.ErrorCode()
+		return code == "AWS.SimpleQueueService.NonExistentQueue" || code == "QueueDoesNotExist"
+	}
+	return false
 }
 
 func receiveMessages(ctx context.Context, api SQSClient, queueURL *string, max int32, waitTime *int32) ([]types.Message, error) {


### PR DESCRIPTION
This change adds unit/integration tests for SQSNotify using GoAWS (`github.com/Admiral-Piett/goaws`). It also updates `isQueueDoesNotExist` to recognize `smithy.APIError` error codes for queue non-existence returned by GoAWS/SQS clones, allowing automatic queue creation to work properly with GoAWS.

---
*PR created automatically by Jules for task [1061479903000809351](https://jules.google.com/task/1061479903000809351) started by @koron*