### PR TITLE
test: add unit and integration tests for auto-extend feature

### DIFF
--- a/internal/sqsnotify/config_test.go
+++ b/internal/sqsnotify/config_test.go
@@ -1,0 +1,23 @@
+package sqsnotify
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewConfigAutoExtendDefaults(t *testing.T) {
+	cfg := NewConfig()
+	if cfg == nil {
+		t.Fatal("NewConfig() returned nil")
+	}
+
+	if cfg.AutoExtend != false {
+		t.Errorf("expected AutoExtend = false, got %v", cfg.AutoExtend)
+	}
+	if cfg.AutoExtendFactor != 2.0 {
+		t.Errorf("expected AutoExtendFactor = 2.0, got %v", cfg.AutoExtendFactor)
+	}
+	if cfg.AutoExtendMax != 64*time.Minute {
+		t.Errorf("expected AutoExtendMax = 64m, got %v", cfg.AutoExtendMax)
+	}
+}

--- a/internal/sqsnotify/sqsnotify_test.go
+++ b/internal/sqsnotify/sqsnotify_test.go
@@ -154,6 +154,9 @@ func TestSQSNotify(t *testing.T) {
 
 		createRes, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
 			QueueName: aws.String(queueName),
+			Attributes: map[string]string{
+				"VisibilityTimeout": "30",
+			},
 		})
 		if err != nil {
 			t.Fatalf("failed to create queue: %v", err)
@@ -210,6 +213,9 @@ func TestSQSNotify(t *testing.T) {
 
 		createRes, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
 			QueueName: aws.String(queueName),
+			Attributes: map[string]string{
+				"VisibilityTimeout": "30",
+			},
 		})
 		if err != nil {
 			t.Fatalf("failed to create queue: %v", err)
@@ -254,6 +260,150 @@ func TestSQSNotify(t *testing.T) {
 		runErr := <-errCh
 		if runErr != nil && !errorsIsCanceled(runErr) {
 			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+	})
+
+	t.Run("AutoExtend Enabled - Fetches Queue VisibilityTimeout and Processes Message", func(t *testing.T) {
+		srv, sqsClient := setupGoAWSServer(t)
+
+		queueName := "test-goaws-auto-extend"
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		createRes, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+			QueueName: aws.String(queueName),
+			Attributes: map[string]string{
+				"VisibilityTimeout": "30",
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to create queue: %v", err)
+		}
+
+		wt := int64(1)
+		cfg := NewConfig()
+		cfg.Endpoint = srv.URL()
+		cfg.Region = "us-east-1"
+		cfg.QueueName = queueName
+		cfg.CreateQueue = false
+		cfg.CmdName = os.Args[0]
+		cfg.CmdArgs = []string{"-test.run=TestHelperProcess"}
+		cfg.RemovePolicy = Succeed
+		cfg.WaitTime = &wt
+		cfg.AutoExtend = true
+		cfg.AutoExtendFactor = 2.0
+		cfg.AutoExtendMax = 10 * time.Minute
+
+		sn := New(cfg)
+
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- sn.Run(runCtx, cache.NewMemoryCache(10))
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		if sn.queueVisibilityTimeout <= 0 {
+			t.Errorf("expected queueVisibilityTimeout > 0, got %v", sn.queueVisibilityTimeout)
+		}
+
+		_, err = sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    createRes.QueueUrl,
+			MessageBody: aws.String("hello goaws auto extend"),
+		})
+		if err != nil {
+			t.Fatalf("failed to send message: %v", err)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		runCancel()
+		runErr := <-errCh
+		if runErr != nil && !errorsIsCanceled(runErr) {
+			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+	})
+
+	t.Run("AutoExtend with BeforeExecution Policy Skips Extension Loop", func(t *testing.T) {
+		srv, sqsClient := setupGoAWSServer(t)
+
+		queueName := "test-goaws-auto-extend-before-exec"
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		createRes, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+			QueueName: aws.String(queueName),
+		})
+		if err != nil {
+			t.Fatalf("failed to create queue: %v", err)
+		}
+
+		wt := int64(1)
+		cfg := NewConfig()
+		cfg.Endpoint = srv.URL()
+		cfg.Region = "us-east-1"
+		cfg.QueueName = queueName
+		cfg.CreateQueue = false
+		cfg.CmdName = os.Args[0]
+		cfg.CmdArgs = []string{"-test.run=TestHelperProcess"}
+		cfg.RemovePolicy = BeforeExecution
+		cfg.WaitTime = &wt
+		cfg.AutoExtend = true
+
+		sn := New(cfg)
+
+		runCtx, runCancel := context.WithCancel(ctx)
+		defer runCancel()
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- sn.Run(runCtx, cache.NewMemoryCache(10))
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		_, err = sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    createRes.QueueUrl,
+			MessageBody: aws.String("hello goaws auto extend before execution"),
+		})
+		if err != nil {
+			t.Fatalf("failed to send message: %v", err)
+		}
+
+		time.Sleep(500 * time.Millisecond)
+
+		runCancel()
+		runErr := <-errCh
+		if runErr != nil && !errorsIsCanceled(runErr) {
+			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+	})
+
+	t.Run("autoExtendQLoop Terminates on Context Cancellation", func(t *testing.T) {
+		sn := New(nil)
+		sn.queueVisibilityTimeout = 100 * time.Millisecond
+		sn.AutoExtendFactor = 2.0
+		sn.AutoExtendMax = 1 * time.Minute
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		done := make(chan struct{})
+		go func() {
+			sn.autoExtendQLoop(ctx, nil)
+			close(done)
+		}()
+
+		// Cancel context immediately
+		cancel()
+
+		select {
+		case <-done:
+			// autoExtendQLoop exited cleanly
+		case <-time.After(1 * time.Second):
+			t.Fatal("autoExtendQLoop did not terminate after context cancellation")
 		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -36,27 +37,37 @@ func toRP(s string) sqsnotify.RemovePolicy {
 	}
 }
 
-func main2() error {
-	var (
-		cfg     = sqsnotify.NewConfig()
-		version bool
-		logfile string
-		pidfile string
+type cliParams struct {
+	cfg        *sqsnotify.Config
+	version    bool
+	logfile    string
+	pidfile    string
+	multiplier int
+}
 
+func parseFlags(args []string) (*cliParams, error) {
+	fs := flag.NewFlagSet("sqs-notify", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cfg := sqsnotify.NewConfig()
+
+	var (
+		version      bool
+		logfile      string
+		pidfile      string
 		waitTimeSec  int64
 		removePolicy string
 		multiplier   int
 	)
 
-	flag.StringVar(&cfg.Profile, "profile", "", "AWS profile name")
-	flag.StringVar(&cfg.Region, "region", "us-east-1", "AWS region")
-	flag.StringVar(&cfg.Endpoint, "endpoint", "", "Endpoint of SQS")
-	flag.Var(valid.String(&cfg.QueueName, "").MustSet(), "queue", "SQS queue name")
-	flag.BoolVar(&cfg.CreateQueue, "createqueue", false, "create queue if not exists")
-	flag.IntVar(&cfg.MaxRetries, "max-retries", cfg.MaxRetries, "max retries for AWS")
-	flag.Int64Var(&waitTimeSec, "wait-time-seconds", -1, `wait time in seconds for next polling. (default -1, disabled, use queue default)`)
+	fs.StringVar(&cfg.Profile, "profile", "", "AWS profile name")
+	fs.StringVar(&cfg.Region, "region", "us-east-1", "AWS region")
+	fs.StringVar(&cfg.Endpoint, "endpoint", "", "Endpoint of SQS")
+	fs.Var(valid.String(&cfg.QueueName, "").MustSet(), "queue", "SQS queue name")
+	fs.BoolVar(&cfg.CreateQueue, "createqueue", false, "create queue if not exists")
+	fs.IntVar(&cfg.MaxRetries, "max-retries", cfg.MaxRetries, "max retries for AWS")
+	fs.Int64Var(&waitTimeSec, "wait-time-seconds", -1, `wait time in seconds for next polling. (default -1, disabled, use queue default)`)
 
-	flag.StringVar(&cfg.CacheName, "cache", cfg.CacheName,
+	fs.StringVar(&cfg.CacheName, "cache", cfg.CacheName,
 		`cache name or connection URL
  * memory://?capacity=1000
  * redis://[{USER}:{PASS}@]{HOST}/[{DBNUM}]?[{OPTIONS}]
@@ -68,50 +79,75 @@ func main2() error {
 
    Example to connect the redis on localhost: "redis://:6379"`)
 
-	flag.IntVar(&cfg.Workers, "workers", cfg.Workers, "num of workers")
-	flag.Var(valid.Int(&multiplier, 1).Min(1), "multiplier", `pooling the SQS in multiple runner`)
-	flag.DurationVar(&cfg.Timeout, "timeout", 0, "timeout for command execution (default 0 - no timeout)")
+	fs.IntVar(&cfg.Workers, "workers", cfg.Workers, "num of workers")
+	fs.Var(valid.Int(&multiplier, 1).Min(1), "multiplier", `pooling the SQS in multiple runner`)
+	fs.DurationVar(&cfg.Timeout, "timeout", 0, "timeout for command execution (default 0 - no timeout)")
 
-	flag.Var(valid.String(&removePolicy, rpSucceed).
+	fs.Var(valid.String(&removePolicy, rpSucceed).
 		OneOf(rpSucceed, rpIgnoreFailure, rpBeforeExecution), "remove-policy",
 		`policy to remove messages from SQS
  * succeed          : after execution, succeeded (default)
  * ignore_failure   : after execution, ignore its result
  * before_execution : before execution`)
 
-	flag.BoolVar(&cfg.AutoExtend, "auto-extend", false, `enables automatic message visibility extension`)
-	flag.Var(valid.Float64(&cfg.AutoExtendFactor, 2.0).Min(1.0).Max(10.0),
+	fs.BoolVar(&cfg.AutoExtend, "auto-extend", false, `enables automatic message visibility extension`)
+	fs.Var(valid.Float64(&cfg.AutoExtendFactor, 2.0).Min(1.0).Max(10.0),
 		"auto-extend-factor", `multiplier for extending the visibility timeout exponentially`)
-	flag.Var(valid.Duration(&cfg.AutoExtendMax, 64*time.Minute).Min(time.Minute).Max(4*time.Hour),
+	fs.Var(valid.Duration(&cfg.AutoExtendMax, 64*time.Minute).Min(time.Minute).Max(4*time.Hour),
 		"auto-extend-max", `maximum visibility timeout allowed for a single extension call`)
 
-	flag.BoolVar(&version, "version", false, "show version")
-	flag.StringVar(&logfile, "logfile", "", "log file path")
-	flag.StringVar(&pidfile, "pidfile", "", "PID file path (require -logfile)")
+	fs.BoolVar(&version, "version", false, "show version")
+	fs.StringVar(&logfile, "logfile", "", "log file path")
+	fs.StringVar(&pidfile, "pidfile", "", "PID file path (require -logfile)")
 
-	if err := valid.Parse(flag.CommandLine, os.Args[1:]); err != nil {
-		return err
+	if err := valid.Parse(fs, args); err != nil {
+		return nil, err
 	}
 
 	if version {
-		fmt.Println("sqs-notify2 version:", sqsnotify.Version)
-		os.Exit(1)
+		return &cliParams{cfg: cfg, version: true}, nil
 	}
 
-	if flag.NArg() < 1 {
-		return errors.New("need a notification command")
+	if fs.NArg() < 1 {
+		return nil, errors.New("need a notification command")
 	}
-	args := flag.Args()
+	cmdArgs := fs.Args()
 	cfg.RemovePolicy = toRP(removePolicy)
-	cfg.CmdName = args[0]
-	cfg.CmdArgs = args[1:]
+	cfg.CmdName = cmdArgs[0]
+	cfg.CmdArgs = cmdArgs[1:]
 	if waitTimeSec >= 0 {
 		cfg.WaitTime = &waitTimeSec
 	}
 
 	if cfg.Workers < 1 {
-		return errors.New("\"-worker\" should be greater than 0")
+		return nil, errors.New("\"-worker\" should be greater than 0")
 	}
+
+	return &cliParams{
+		cfg:        cfg,
+		version:    version,
+		logfile:    logfile,
+		pidfile:    pidfile,
+		multiplier: multiplier,
+	}, nil
+}
+
+func main2() error {
+	params, err := parseFlags(os.Args[1:])
+	if err != nil {
+		return err
+	}
+
+	if params.version {
+		fmt.Println("sqs-notify2 version:", sqsnotify.Version)
+		os.Exit(1)
+	}
+
+	cfg := params.cfg
+	multiplier := params.multiplier
+	logfile := params.logfile
+	pidfile := params.pidfile
+
 	if cfg.Workers > 10 {
 		log.Print("\"WARN: -worker 10+\" doesn't have any effects, check \"-multiplier\"")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseFlagsAutoExtend(t *testing.T) {
+	t.Run("default flags", func(t *testing.T) {
+		args := []string{"-queue", "test-queue", "echo", "hello"}
+		params, err := parseFlags(args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if params.cfg.AutoExtend != false {
+			t.Errorf("expected AutoExtend = false, got %v", params.cfg.AutoExtend)
+		}
+		if params.cfg.AutoExtendFactor != 2.0 {
+			t.Errorf("expected AutoExtendFactor = 2.0, got %v", params.cfg.AutoExtendFactor)
+		}
+		if params.cfg.AutoExtendMax != 64*time.Minute {
+			t.Errorf("expected AutoExtendMax = 64m, got %v", params.cfg.AutoExtendMax)
+		}
+	})
+
+	t.Run("enable auto-extend with custom factor and max", func(t *testing.T) {
+		args := []string{
+			"-queue", "test-queue",
+			"-auto-extend",
+			"-auto-extend-factor", "3.0",
+			"-auto-extend-max", "2h",
+			"echo", "hello",
+		}
+		params, err := parseFlags(args)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if params.cfg.AutoExtend != true {
+			t.Errorf("expected AutoExtend = true, got %v", params.cfg.AutoExtend)
+		}
+		if params.cfg.AutoExtendFactor != 3.0 {
+			t.Errorf("expected AutoExtendFactor = 3.0, got %v", params.cfg.AutoExtendFactor)
+		}
+		if params.cfg.AutoExtendMax != 2*time.Hour {
+			t.Errorf("expected AutoExtendMax = 2h, got %v", params.cfg.AutoExtendMax)
+		}
+	})
+
+	t.Run("auto-extend-factor below min bound", func(t *testing.T) {
+		args := []string{
+			"-queue", "test-queue",
+			"-auto-extend",
+			"-auto-extend-factor", "0.5",
+			"echo", "hello",
+		}
+		_, err := parseFlags(args)
+		if err == nil {
+			t.Errorf("expected error when auto-extend-factor < 1.0, got nil")
+		}
+	})
+
+	t.Run("auto-extend-factor above max bound", func(t *testing.T) {
+		args := []string{
+			"-queue", "test-queue",
+			"-auto-extend",
+			"-auto-extend-factor", "10.5",
+			"echo", "hello",
+		}
+		_, err := parseFlags(args)
+		if err == nil {
+			t.Errorf("expected error when auto-extend-factor > 10.0, got nil")
+		}
+	})
+
+	t.Run("auto-extend-max below min bound", func(t *testing.T) {
+		args := []string{
+			"-queue", "test-queue",
+			"-auto-extend",
+			"-auto-extend-max", "30s",
+			"echo", "hello",
+		}
+		_, err := parseFlags(args)
+		if err == nil {
+			t.Errorf("expected error when auto-extend-max < 1m, got nil")
+		}
+	})
+
+	t.Run("auto-extend-max above max bound", func(t *testing.T) {
+		args := []string{
+			"-queue", "test-queue",
+			"-auto-extend",
+			"-auto-extend-max", "5h",
+			"echo", "hello",
+		}
+		_, err := parseFlags(args)
+		if err == nil {
+			t.Errorf("expected error when auto-extend-max > 4h, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Added comprehensive tests for the `-auto-extend` feature including config defaults, CLI flag parsing/validation, and runtime message visibility timeout extension loop behavior.

---
*PR created automatically by Jules for task [17195418619936668980](https://jules.google.com/task/17195418619936668980) started by @koron*