### PR TITLE
fix: print usage and exit 0 when help flag is provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,9 +45,11 @@ type notifyParams struct {
 	multiplier int
 }
 
-func parseFlags(args []string) (*notifyParams, error) {
+func parseFlags(args []string, output io.Writer) (*notifyParams, error) {
 	fs := flag.NewFlagSet("sqs-notify", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
+	if output != nil {
+		fs.SetOutput(output)
+	}
 	cfg := sqsnotify.NewConfig()
 
 	var (
@@ -101,6 +103,9 @@ func parseFlags(args []string) (*notifyParams, error) {
 	fs.StringVar(&pidfile, "pidfile", "", "PID file path (require -logfile)")
 
 	if err := valid.Parse(fs, args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
 		return nil, err
 	}
 
@@ -133,7 +138,7 @@ func parseFlags(args []string) (*notifyParams, error) {
 }
 
 func main2() error {
-	params, err := parseFlags(os.Args[1:])
+	params, err := parseFlags(os.Args[1:], nil)
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"testing"
 	"time"
 )
@@ -8,7 +9,7 @@ import (
 func TestParseFlagsAutoExtend(t *testing.T) {
 	t.Run("default flags", func(t *testing.T) {
 		args := []string{"-queue", "test-queue", "echo", "hello"}
-		params, err := parseFlags(args)
+		params, err := parseFlags(args, io.Discard)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -31,7 +32,7 @@ func TestParseFlagsAutoExtend(t *testing.T) {
 			"-auto-extend-max", "2h",
 			"echo", "hello",
 		}
-		params, err := parseFlags(args)
+		params, err := parseFlags(args, io.Discard)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -53,7 +54,7 @@ func TestParseFlagsAutoExtend(t *testing.T) {
 			"-auto-extend-factor", "0.5",
 			"echo", "hello",
 		}
-		_, err := parseFlags(args)
+		_, err := parseFlags(args, io.Discard)
 		if err == nil {
 			t.Errorf("expected error when auto-extend-factor < 1.0, got nil")
 		}
@@ -66,7 +67,7 @@ func TestParseFlagsAutoExtend(t *testing.T) {
 			"-auto-extend-factor", "10.5",
 			"echo", "hello",
 		}
-		_, err := parseFlags(args)
+		_, err := parseFlags(args, io.Discard)
 		if err == nil {
 			t.Errorf("expected error when auto-extend-factor > 10.0, got nil")
 		}
@@ -79,7 +80,7 @@ func TestParseFlagsAutoExtend(t *testing.T) {
 			"-auto-extend-max", "30s",
 			"echo", "hello",
 		}
-		_, err := parseFlags(args)
+		_, err := parseFlags(args, io.Discard)
 		if err == nil {
 			t.Errorf("expected error when auto-extend-max < 1m, got nil")
 		}
@@ -92,7 +93,7 @@ func TestParseFlagsAutoExtend(t *testing.T) {
 			"-auto-extend-max", "5h",
 			"echo", "hello",
 		}
-		_, err := parseFlags(args)
+		_, err := parseFlags(args, io.Discard)
 		if err == nil {
 			t.Errorf("expected error when auto-extend-max > 4h, got nil")
 		}


### PR DESCRIPTION
## Summary
Previously, `parseFlags` unconditionally set the flag output to `io.Discard` for testing purposes, which prevented usage information from being displayed when `-h` / `--help` was requested. This PR updates `parseFlags` to accept an explicit `output io.Writer` parameter, ensuring tests can suppress output while normal execution prints the usage message and exits with status code `0`.

## Changes
- Updated `parseFlags` signature to accept `output io.Writer` so that output is only redirected to `io.Discard` during test runs.
- Configured `FlagSet.SetOutput(output)` in `parseFlags` when `output` is non-nil.
- Handled `errors.Is(err, flag.ErrHelp)` after `valid.Parse` to call `os.Exit(0)` directly upon help requests.
- Updated `main_test.go` to pass `io.Discard` as the output writer across test cases.