### PR TITLE
fix: validate -workers flag range and clamp worker count

### DIFF
--- a/internal/sqsnotify/sqsnotify.go
+++ b/internal/sqsnotify/sqsnotify.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-const maxMsg = 10
+const MaxMsg = 10
 
 var discardLog = log.New(io.Discard, "", 0)
 
@@ -170,7 +170,7 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 	var round = 0
 	for {
 		// receive messages.
-		msgs, err := sn.receiveQ(ctx, client, &qu, maxMsg)
+		msgs, err := sn.receiveQ(ctx, client, &qu, MaxMsg)
 		if err != nil {
 			return err
 		}
@@ -211,7 +211,7 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 		}
 
 		// run as commands
-		sem := sn.newWeighted()
+		sem := semaphore.NewWeighted(int64(min(max(1, sn.Workers), MaxMsg)))
 		var wg sync.WaitGroup
 		for i, m := range msgs {
 			res := &result{round: round, index: i, msg: m}
@@ -448,14 +448,6 @@ func (sn *SQSNotify) handleCopyMessageFailure(err error, m *types.Message) {
 		msgID = *m.MessageId
 	}
 	sn.log().Printf("failed to pass message body: id=%s err=%s", msgID, err)
-}
-
-func (sn *SQSNotify) newWeighted() *semaphore.Weighted {
-	n := sn.Workers
-	if n < 0 || n > maxMsg {
-		n = 4
-	}
-	return semaphore.NewWeighted(int64(n))
 }
 
 func (sn *SQSNotify) clearResults() {

--- a/main.go
+++ b/main.go
@@ -81,7 +81,10 @@ func parseFlags(args []string, output io.Writer) (*notifyParams, error) {
 
    Example to connect the redis on localhost: "redis://:6379"`)
 
-	fs.IntVar(&cfg.Workers, "workers", cfg.Workers, "num of workers")
+	workersMax := sqsnotify.MaxMsg
+	workersDefault := min(4, workersMax)
+	fs.Var(valid.Int(&cfg.Workers, workersDefault).Min(1).Max(workersMax),
+		"workers", "num of workers")
 	fs.Var(valid.Int(&multiplier, 1).Min(1), "multiplier", `pooling the SQS in multiple runner`)
 	fs.DurationVar(&cfg.Timeout, "timeout", 0, "timeout for command execution (default 0 - no timeout)")
 
@@ -124,10 +127,6 @@ func parseFlags(args []string, output io.Writer) (*notifyParams, error) {
 		cfg.WaitTime = &waitTimeSec
 	}
 
-	if cfg.Workers < 1 {
-		return nil, errors.New("\"-worker\" should be greater than 0")
-	}
-
 	return &notifyParams{
 		cfg:        cfg,
 		version:    version,
@@ -152,10 +151,6 @@ func main2() error {
 	multiplier := params.multiplier
 	logfile := params.logfile
 	pidfile := params.pidfile
-
-	if cfg.Workers > 10 {
-		log.Print("\"WARN: -worker 10+\" doesn't have any effects, check \"-multiplier\"")
-	}
 
 	// Setup logger.
 	// FIXME: test logging features.


### PR DESCRIPTION
## Description
- Export `maxMsg` as `sqsnotify.MaxMsg` so the CLI can reference the message cap constant.
- Enforce `-workers` flag range `[1, MaxMsg]` in `parseFlags` using `valid.Int`.
- Inline semaphore initialization using `min`/`max` bounds (`min(max(1, sn.Workers), MaxMsg)`), replacing the obsolete `newWeighted()` helper and its fallback logic.
- Remove redundant manual worker count checks and log warnings.

## Motivation
Previously, invalid `-workers` flag values were partially validated in `parseFlags` and `main2()`, with fallback behavior handled inside `newWeighted()`. This change centralizes flag range validation at option parsing time and ensures safe worker limits across both CLI usage and library calls.