### PR TITLE
feat(sqsnotify): add graceful shutdown support and configurable grace periods

### DIFF
--- a/internal/sqsnotify/config.go
+++ b/internal/sqsnotify/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	AutoExtendFactor float64
 	AutoExtendMax    time.Duration
 
+	GracePeriodCommand time.Duration
+	GracePeriodCleanup time.Duration
+
 	CmdName string
 	CmdArgs []string
 
@@ -52,5 +55,8 @@ func NewConfig() *Config {
 
 		AutoExtendFactor: 2.0,
 		AutoExtendMax:    64 * time.Minute,
+
+		GracePeriodCommand: 10 * time.Second,
+		GracePeriodCleanup: 30 * time.Second,
 	}
 }

--- a/internal/sqsnotify/sqsnotify.go
+++ b/internal/sqsnotify/sqsnotify.go
@@ -31,14 +31,13 @@ var discardLog = log.New(io.Discard, "", 0)
 type SQSNotify struct {
 	Config
 
-	l       sync.Mutex
-	results []*result
-	cache   cache.Cache
+	cache          cache.Cache
+	sqsClient      *sqs.Client
+	queueURL       string
+	initialTimeout time.Duration
 
-	sqsClient *sqs.Client
-	queueURL  string
-
-	queueVisibilityTimeout time.Duration
+	resultMu sync.Mutex
+	results  []*result
 }
 
 // New creates a SQSNotify object with configuration.
@@ -47,8 +46,8 @@ func New(cfg *Config) *SQSNotify {
 		cfg = NewConfig()
 	}
 	return &SQSNotify{
-		Config:                 *cfg,
-		queueVisibilityTimeout: 30 * time.Second,
+		Config:         *cfg,
+		initialTimeout: 30 * time.Second,
 	}
 }
 
@@ -71,16 +70,31 @@ func (sn *SQSNotify) logResult(r *result) {
 	sn.log().Printf("\tNOT_EXECUTED\tstage:%[2]s error:%[1]s", r.err, r.stg)
 }
 
-// Run runs SQS notification service.
+// Run executes the SQS message monitoring/notification loop. Non-reentrant.
 func (sn *SQSNotify) Run(ctx context.Context, cache cache.Cache) error {
-	svc, err := sn.newSQS(ctx)
+	sqsClient, err := sn.newSQS(ctx)
 	if err != nil {
 		return err
 	}
-	sn.cache = cache
-	sn.sqsClient = svc
 
-	return sn.run(ctx, svc)
+	queueURL, err := sn.ensureQueue(ctx, sqsClient)
+	if err != nil {
+		return err
+	}
+
+	if sn.AutoExtend {
+		timeout, err := sn.getVisibilityTimeout(ctx, sqsClient, queueURL)
+		if err != nil {
+			return err
+		}
+		sn.initialTimeout = timeout
+	}
+
+	sn.cache = cache
+	sn.sqsClient = sqsClient
+	sn.queueURL = queueURL
+
+	return sn.run(ctx)
 }
 
 func (sn *SQSNotify) newSQS(ctx context.Context) (*sqs.Client, error) {
@@ -140,37 +154,32 @@ func (sn *SQSNotify) ensureQueue(ctx context.Context, client *sqs.Client) (strin
 	return *rCreate.QueueUrl, nil
 }
 
-func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
-	qu, err := sn.ensureQueue(ctx, client)
+func (sn *SQSNotify) getVisibilityTimeout(ctx context.Context, client *sqs.Client, queueURL string) (time.Duration, error) {
+	out, err := client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl: &queueURL,
+		AttributeNames: []types.QueueAttributeName{
+			types.QueueAttributeNameVisibilityTimeout,
+		},
+	})
 	if err != nil {
-		return err
+		return 0, err
 	}
-	sn.queueURL = qu
-
-	// Get visibility timeout.
-	if sn.AutoExtend {
-		out, err := client.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
-			QueueUrl: &qu,
-			AttributeNames: []types.QueueAttributeName{
-				types.QueueAttributeNameVisibilityTimeout,
-			},
-		})
-		if err != nil {
-			return err
-		}
-		if timeout, ok := out.Attributes[string(types.QueueAttributeNameVisibilityTimeout)]; ok {
-			sec, err := strconv.Atoi(timeout)
-			if err != nil {
-				return err
-			}
-			sn.queueVisibilityTimeout = time.Duration(sec) * time.Second
-		}
+	timeout, ok := out.Attributes[string(types.QueueAttributeNameVisibilityTimeout)]
+	if !ok {
+		return 30 * time.Second, nil
 	}
+	sec, err := strconv.Atoi(timeout)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(sec) * time.Second, nil
+}
 
+func (sn *SQSNotify) run(ctx context.Context) error {
 	var round = 0
 	for {
 		// receive messages.
-		msgs, err := sn.receiveQ(ctx, client, &qu, MaxMsg)
+		msgs, err := sn.receiveQ(ctx, MaxMsg)
 		if err != nil {
 			return err
 		}
@@ -189,7 +198,7 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 					ReceiptHandle: m.ReceiptHandle,
 				})
 			}
-			err := sn.deleteQ(ctx, client, &qu, entries)
+			err := sn.deleteQ(ctx, entries)
 			if err != nil {
 				return err
 			}
@@ -224,12 +233,14 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 			go func(r, n int, m types.Message, res *result) {
 				defer wg.Done()
 				res.stg = stage.Lock
+
 				err := sem.Acquire(ctx, 1)
 				if err != nil {
 					sn.addResult(res.withErr(err))
 					return
 				}
 				defer sem.Release(1)
+
 				res.stg = stage.Exec
 				err = sn.cacheUpdate(res, stage.Exec)
 				if err != nil {
@@ -241,6 +252,7 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 					sn.addResult(res.withErr(err))
 					return
 				}
+
 				res.stg = stage.Done
 				err = sn.cacheUpdate(res, stage.Done)
 				if err != nil {
@@ -254,7 +266,7 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 		extendCancel()
 
 		// delete messages
-		err = sn.deleteQ(ctx, client, &qu, sn.deleteEntries())
+		err = sn.deleteQ(ctx, sn.deleteEntries())
 		if err != nil {
 			return err
 		}
@@ -264,6 +276,8 @@ func (sn *SQSNotify) run(ctx context.Context, client *sqs.Client) error {
 }
 
 func (sn *SQSNotify) deleteEntries() []types.DeleteMessageBatchRequestEntry {
+	sn.resultMu.Lock()
+	defer sn.resultMu.Unlock()
 	var entries []types.DeleteMessageBatchRequestEntry
 	for _, r := range sn.results {
 		if !sn.shouldRemoveAfter(r) {
@@ -366,15 +380,15 @@ func (sn *SQSNotify) execCmd(ctx context.Context, m *types.Message) error {
 	return nil
 }
 
-func (sn *SQSNotify) receiveQ(ctx context.Context, client *sqs.Client, queueURL *string, max int32) ([]types.Message, error) {
+func (sn *SQSNotify) receiveQ(ctx context.Context, max int32) ([]types.Message, error) {
 	input := &sqs.ReceiveMessageInput{
-		QueueUrl:            queueURL,
+		QueueUrl:            &sn.queueURL,
 		MaxNumberOfMessages: max,
 	}
 	if sn.WaitTime != nil {
 		input.WaitTimeSeconds = int32(*sn.WaitTime)
 	}
-	out, err := client.ReceiveMessage(ctx, input)
+	out, err := sn.sqsClient.ReceiveMessage(ctx, input)
 	if err != nil {
 		return nil, err
 	}
@@ -382,7 +396,7 @@ func (sn *SQSNotify) receiveQ(ctx context.Context, client *sqs.Client, queueURL 
 }
 
 func (sn *SQSNotify) autoExtendQLoop(ctx context.Context, entries []types.ChangeMessageVisibilityBatchRequestEntry) {
-	currTimeout := sn.queueVisibilityTimeout
+	currTimeout := sn.initialTimeout
 	for {
 		wait := max(currTimeout*4/5, currTimeout-15*time.Second)
 		if wait < time.Second {
@@ -396,20 +410,27 @@ func (sn *SQSNotify) autoExtendQLoop(ctx context.Context, entries []types.Change
 		}
 		// Extend visibility timeout of the message.
 		next := min(time.Duration(float64(currTimeout)*sn.AutoExtendFactor), sn.AutoExtendMax, 12*time.Hour)
-		nextSec := int32(next.Seconds())
-		for i := range entries {
-			entries[i].VisibilityTimeout = nextSec
-		}
-		_, err := sn.sqsClient.ChangeMessageVisibilityBatch(ctx, &sqs.ChangeMessageVisibilityBatchInput{
-			Entries:  entries,
-			QueueUrl: &sn.queueURL,
-		})
+		err := sn.changeVisibilityQ(ctx, int32(next.Seconds()), entries)
 		if err != nil {
 			sn.log().Printf("failed to extend message visibility timeout: err=%s", err)
 			return
 		}
 		currTimeout = next
 	}
+}
+
+func (sn *SQSNotify) changeVisibilityQ(ctx context.Context, sec int32, entries []types.ChangeMessageVisibilityBatchRequestEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	for i := range entries {
+		entries[i].VisibilityTimeout = sec
+	}
+	_, err := sn.sqsClient.ChangeMessageVisibilityBatch(ctx, &sqs.ChangeMessageVisibilityBatchInput{
+		Entries:  entries,
+		QueueUrl: &sn.queueURL,
+	})
+	return err
 }
 
 type DeleteFailure struct {
@@ -420,13 +441,13 @@ func (df *DeleteFailure) Error() string {
 	return fmt.Sprintf("failed to delete %d messages", len(df.Failed))
 }
 
-func (sn *SQSNotify) deleteQ(ctx context.Context, client *sqs.Client, queueURL *string, entries []types.DeleteMessageBatchRequestEntry) error {
+func (sn *SQSNotify) deleteQ(ctx context.Context, entries []types.DeleteMessageBatchRequestEntry) error {
 	if len(entries) == 0 {
 		return nil
 	}
 
-	out, err := client.DeleteMessageBatch(ctx, &sqs.DeleteMessageBatchInput{
-		QueueUrl: queueURL,
+	out, err := sn.sqsClient.DeleteMessageBatch(ctx, &sqs.DeleteMessageBatchInput{
+		QueueUrl: &sn.queueURL,
 		Entries:  entries,
 	})
 	if err != nil {
@@ -451,16 +472,16 @@ func (sn *SQSNotify) handleCopyMessageFailure(err error, m *types.Message) {
 }
 
 func (sn *SQSNotify) clearResults() {
-	sn.l.Lock()
+	sn.resultMu.Lock()
 	sn.results = sn.results[:0]
-	sn.l.Unlock()
+	sn.resultMu.Unlock()
 }
 
 func (sn *SQSNotify) addResult(r *result) {
 	sn.logResult(r)
-	sn.l.Lock()
+	sn.resultMu.Lock()
 	sn.results = append(sn.results, r)
-	sn.l.Unlock()
+	sn.resultMu.Unlock()
 }
 
 type result struct {

--- a/internal/sqsnotify/sqsnotify.go
+++ b/internal/sqsnotify/sqsnotify.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -35,6 +36,8 @@ type SQSNotify struct {
 	sqsClient      *sqs.Client
 	queueURL       string
 	initialTimeout time.Duration
+
+	extendedTimeout atomic.Bool
 
 	resultMu sync.Mutex
 	results  []*result
@@ -175,9 +178,32 @@ func (sn *SQSNotify) getVisibilityTimeout(ctx context.Context, client *sqs.Clien
 	return time.Duration(sec) * time.Second, nil
 }
 
+// createGracefulContext creates a new context.Context that remains active for
+// an additional grace period after the parent context is cancelled.
+func createGracefulContext(parent context.Context, gracePeriod time.Duration) (context.Context, context.CancelFunc) {
+	baseCtx := context.WithoutCancel(parent)
+	graceCtx, cancel := context.WithCancel(baseCtx)
+	stop := context.AfterFunc(parent, func() {
+		timer := time.AfterFunc(gracePeriod, func() {
+			cancel()
+		})
+		_ = timer
+	})
+	return graceCtx, func() {
+		stop()
+		cancel()
+	}
+}
+
 func (sn *SQSNotify) run(ctx context.Context) error {
+	commandCtx, cmdCancel := createGracefulContext(ctx, sn.GracePeriodCommand)
+	defer cmdCancel()
+	cleanupCtx, deleteCancel := createGracefulContext(ctx, sn.GracePeriodCleanup)
+	defer deleteCancel()
+
 	var round = 0
 	for {
+		sn.extendedTimeout.Store(false)
 		// receive messages.
 		msgs, err := sn.receiveQ(ctx, MaxMsg)
 		if err != nil {
@@ -236,6 +262,9 @@ func (sn *SQSNotify) run(ctx context.Context) error {
 
 				err := sem.Acquire(ctx, 1)
 				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						sn.cacheDelete(res, stage.Canceled)
+					}
 					sn.addResult(res.withErr(err))
 					return
 				}
@@ -247,8 +276,12 @@ func (sn *SQSNotify) run(ctx context.Context) error {
 					sn.addResult(res.withErr(err))
 					return
 				}
-				err = sn.execCmd(ctx, &m)
+
+				err = sn.execCmd(commandCtx, &m)
 				if err != nil {
+					if errors.Is(commandCtx.Err(), context.Canceled) {
+						sn.cacheDelete(res, stage.Canceled)
+					}
 					sn.addResult(res.withErr(err))
 					return
 				}
@@ -265,30 +298,56 @@ func (sn *SQSNotify) run(ctx context.Context) error {
 		wg.Wait()
 		extendCancel()
 
-		// delete messages
-		err = sn.deleteQ(ctx, sn.deleteEntries())
-		if err != nil {
-			return err
+		resetEntries, deleteEntries := sn.cleanupResults()
+		if len(resetEntries) > 0 && sn.extendedTimeout.Load() {
+			err := sn.changeVisibilityQ(cleanupCtx, 0, resetEntries)
+			if err != nil {
+				sn.log().Printf("failed to reset message visiblity: %s", err)
+			}
 		}
+		if len(deleteEntries) > 0 {
+			err := sn.deleteQ(cleanupCtx, deleteEntries)
+			if err != nil {
+				sn.log().Printf("failed to delete messages: %s", err)
+			}
+		}
+
 		sn.clearResults()
 		round++
+
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 	}
 }
 
-func (sn *SQSNotify) deleteEntries() []types.DeleteMessageBatchRequestEntry {
+func (sn *SQSNotify) cleanupResults() ([]types.ChangeMessageVisibilityBatchRequestEntry, []types.DeleteMessageBatchRequestEntry) {
 	sn.resultMu.Lock()
 	defer sn.resultMu.Unlock()
-	var entries []types.DeleteMessageBatchRequestEntry
+	var (
+		resetEntries  []types.ChangeMessageVisibilityBatchRequestEntry
+		deleteEntries []types.DeleteMessageBatchRequestEntry
+	)
 	for _, r := range sn.results {
-		if !sn.shouldRemoveAfter(r) {
+		if r.stg == stage.Canceled {
+			resetEntries = append(resetEntries, types.ChangeMessageVisibilityBatchRequestEntry{
+				Id:            r.msg.MessageId,
+				ReceiptHandle: r.msg.ReceiptHandle,
+			})
+			// For the result of `stage.Canceled`, `shouldRemoveAfter` always
+			// returns `false`, so there is no need to determine whether to
+			// delete it.
 			continue
 		}
-		entries = append(entries, types.DeleteMessageBatchRequestEntry{
-			Id:            r.msg.MessageId,
-			ReceiptHandle: r.msg.ReceiptHandle,
-		})
+		if sn.shouldRemoveAfter(r) {
+			deleteEntries = append(deleteEntries, types.DeleteMessageBatchRequestEntry{
+				Id:            r.msg.MessageId,
+				ReceiptHandle: r.msg.ReceiptHandle,
+			})
+		}
 	}
-	return entries
+	sn.results = sn.results[:0]
+	return resetEntries, deleteEntries
 }
 
 func (sn *SQSNotify) cacheInsert(r *result, stg stage.Stage) error {
@@ -314,6 +373,14 @@ func (sn *SQSNotify) cacheUpdate(r *result, stg stage.Stage) error {
 		return err
 	}
 	return nil
+}
+
+func (sn *SQSNotify) cacheDelete(r *result, stg stage.Stage) error {
+	r.stg = stg
+	if r.msg.MessageId == nil {
+		return nil
+	}
+	return sn.cache.Delete(*r.msg.MessageId)
 }
 
 func (sn *SQSNotify) shouldRemoveAfter(r *result) bool {
@@ -416,6 +483,7 @@ func (sn *SQSNotify) autoExtendQLoop(ctx context.Context, entries []types.Change
 			return
 		}
 		currTimeout = next
+		sn.extendedTimeout.Store(true)
 	}
 }
 

--- a/internal/sqsnotify/sqsnotify_test.go
+++ b/internal/sqsnotify/sqsnotify_test.go
@@ -306,10 +306,6 @@ func TestSQSNotify(t *testing.T) {
 
 		time.Sleep(100 * time.Millisecond)
 
-		if sn.queueVisibilityTimeout <= 0 {
-			t.Errorf("expected queueVisibilityTimeout > 0, got %v", sn.queueVisibilityTimeout)
-		}
-
 		_, err = sqsClient.SendMessage(ctx, &sqs.SendMessageInput{
 			QueueUrl:    createRes.QueueUrl,
 			MessageBody: aws.String("hello goaws auto extend"),
@@ -324,6 +320,10 @@ func TestSQSNotify(t *testing.T) {
 		runErr := <-errCh
 		if runErr != nil && !errorsIsCanceled(runErr) {
 			t.Fatalf("SQSNotify.Run returned unexpected error: %v", runErr)
+		}
+
+		if sn.initialTimeout <= 0 {
+			t.Errorf("expected initialTimeout > 0, got %v", sn.initialTimeout)
 		}
 	})
 
@@ -383,8 +383,13 @@ func TestSQSNotify(t *testing.T) {
 	})
 
 	t.Run("autoExtendQLoop Terminates on Context Cancellation", func(t *testing.T) {
+		// Note: this only exercises the first iteration's ctx.Done() select,
+		// i.e. termination while waiting before any API call. sn.sqsClient
+		// stays nil and entries is empty, so reaching changeVisibilityQ is
+		// safe only thanks to its empty-entries guard. Termination during an
+		// in-flight batch call is not covered here.
 		sn := New(nil)
-		sn.queueVisibilityTimeout = 100 * time.Millisecond
+		sn.initialTimeout = 100 * time.Millisecond
 		sn.AutoExtendFactor = 2.0
 		sn.AutoExtendMax = 1 * time.Minute
 

--- a/internal/stage/stage.go
+++ b/internal/stage/stage.go
@@ -13,6 +13,8 @@ const (
 	Lock
 	// Exec means "executing"
 	Exec
+	// Canceled means "canceled"
+	Canceled
 	// Done means "done execution"
 	Done
 )
@@ -32,6 +34,8 @@ func (stg Stage) String() string {
 		return "Lock"
 	case Exec:
 		return "Exec"
+	case Canceled:
+		return "Canceled"
 	case Done:
 		return "Done"
 	default:

--- a/main.go
+++ b/main.go
@@ -102,6 +102,11 @@ func parseFlags(args []string, output io.Writer) (*notifyParams, error) {
 	fs.Var(valid.Duration(&cfg.AutoExtendMax, 64*time.Minute).Min(time.Minute).Max(4*time.Hour),
 		"auto-extend-max", `maximum visibility timeout allowed for a single extension call`)
 
+	fs.Var(valid.Duration(&cfg.GracePeriodCommand, 10*time.Second).Min(time.Second),
+		"grace-period-command", `grace period before cancelling the command`)
+	fs.Var(valid.Duration(&cfg.GracePeriodCleanup, 30*time.Second).Min(time.Second),
+		"grace-period-cleanup", `grace period required for cancellation processing`)
+
 	fs.BoolVar(&version, "version", false, "show version")
 	fs.StringVar(&logfile, "logfile", "", "log file path")
 	fs.StringVar(&pidfile, "pidfile", "", "PID file path (require -logfile)")
@@ -144,8 +149,12 @@ func main2() error {
 	}
 
 	if params.version {
-		fmt.Println("sqs-notify2 version:", sqsnotify.Version)
+		fmt.Println("sqs-notify version:", sqsnotify.Version)
 		os.Exit(1)
+	}
+
+	if params.cfg.GracePeriodCleanup <= params.cfg.GracePeriodCommand {
+		return errors.New("grace period for cancel should be longer than grace period for command")
 	}
 
 	cfg := params.cfg

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 	"time"
 
 	valid "github.com/koron/go-valid"
@@ -169,20 +170,8 @@ func main2() error {
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	sig := make(chan os.Signal, 1)
-	go func() {
-		for {
-			s := <-sig
-			if s == os.Interrupt {
-				cancel()
-				signal.Stop(sig)
-				close(sig)
-				return
-			}
-		}
-	}()
-	signal.Notify(sig, os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
 	c, err := cache.NewCache(ctx, cfg.CacheName)
 	if err != nil {
@@ -199,7 +188,7 @@ func main2() error {
 		go func(id int) {
 			defer sg.Done()
 			err := sqsnotify.New(cfg).Run(ctx, c)
-			if isCancel(err) {
+			if errors.Is(err, context.Canceled) {
 				return
 			}
 			mu.Lock()
@@ -215,10 +204,6 @@ func main2() error {
 	}
 
 	return nil
-}
-
-func isCancel(err error) bool {
-	return errors.Is(err, context.Canceled)
 }
 
 func main() {


### PR DESCRIPTION
### Summary
Implements graceful shutdown handling when receiving cancellation signals (e.g., `SIGINT`/`SIGTERM`).

During a shutdown event, active command execution processes are given a configurable grace period to complete before cancellation. Post-cancellation cleanup is handled reliably, including deleting successfully completed messages, resetting SQS visibility timeouts (`VisibilityTimeout=0`) for unfinished or interrupted tasks, and clearing corresponding cache entries.

### Key Changes
- **Graceful Context Management**: Added `createGracefulContext()` utilizing `context.WithoutCancel` and `context.AfterFunc` to grant extended execution/cleanup periods after the parent context is cancelled.
- **Configurable Grace Periods**: Added `GracePeriodCommand` and `GracePeriodCleanup` to `Config`, exposed via CLI flags (`--grace-period-command`, `--grace-period-cleanup`), with validation to ensure cleanup duration exceeds command grace period.
- **Cancellation Handling & Cleanup Logic**:
  - Introduced `stage.Canceled` to represent cancelled task execution states.
  - Implemented `cleanupResults()` to separate results into message deletion entries vs. SQS visibility reset entries.
  - Added `cacheDelete()` to clear cache entries for cancelled messages so they can be re-processed safely upon restart.
- **Thread-Safety**: Utilized `atomic.Bool` (`extendedTimeout`) to track SQS visibility extension status safely across concurrent goroutines.

---

Fixed #57 