### PR TITLE
feat(main): log graceful shutdown progress and support second signal for instant exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,6 +182,28 @@ func main2() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	stopLog := context.AfterFunc(ctx, func() {
+		logger := cfg.Logger
+		if logger == nil {
+			logger = log.Default()
+		}
+		logger.Printf("received signal, starting graceful shutdown (waiting up to %s)...", cfg.GracePeriodCleanup)
+		logger.Println("press Ctrl+C again to force exit")
+		// Create a channel to receive the second SIGINT/SIGTERM and wait.
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+		go func() {
+			defer signal.Stop(sigCh)
+			select {
+			case <-sigCh:
+				logger.Println("received second signal, forcing exit now")
+				os.Exit(1)
+			case <-ctx.Done():
+			}
+		}()
+	})
+	defer stopLog()
+
 	c, err := cache.NewCache(ctx, cfg.CacheName)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary
Enhances the CLI graceful shutdown behavior by logging progress during shutdown and introducing a second signal handler to allow immediate process exit.

### Key Changes
- **Shutdown Progress Logging**: Added logging via `context.AfterFunc` when receiving a cancellation signal (`SIGINT`/`SIGTERM`), informing the user that graceful shutdown has started and displaying the maximum cleanup wait time.
- **Logger Fallback**: Configured log messages to use `cfg.Logger` if defined, with a fallback to `log.Default()`, ensuring shutdown events are captured in log files when configured.
- **Double Ctrl+C Interrupt Support**: Registered a second signal handler during the graceful shutdown window. Receiving a second `SIGINT` or `SIGTERM` triggers an immediate forced exit (`os.Exit(1)`).