### PR TITLE
docs: update AGENTS.md for v2.3.0 release

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,9 @@ jobs:
         while read -r path dir; do
           [ -z "$path" ] && continue
           name=$(basename "$path")
+          if [[ "$name" =~ ^v[1-9][0-9]*$ ]]; then
+            name=$(basename "$(dirname "$path")")
+          fi
           if [ -f "$dir/.norelease" ] ; then
             printf "Skipped %s\t(%s), due to %s/.norelease found\n" "$name" "$dir" "$dir"
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,35 @@
 # AGENTS.md
 
-Go module `github.com/koron/sqs-notify` (go 1.26). CLI that polls an SQS queue
-and executes a command per message (message body on STDIN).
+Go module `github.com/koron/sqs-notify/v2` (go 1.26). CLI that polls an SQS
+queue and executes a command per message (message body on STDIN).
 
 ## Layout
 
-- Root package (`main.go`, `jobs.go`, `daemon.go`, `config.go`): legacy v1.
-  Docs: `doc/v1.md`. Do not extend v1; new work goes to v2.
-- `sqsnotify2/`: v2 library. `cmd/sqs-notify2/`: current entrypoint
-  (installed via `go install github.com/koron/sqs-notify/cmd/sqs-notify2@latest`).
+- Root package (`main.go`): the `sqs-notify` v2 CLI (flag parsing, daemon,
+  log/pidfile, graceful shutdown wiring).
+- `internal/sqsnotify`: core library (queue polling, workers, remove
+  policies, config).
+- `internal/cache`: message cache (`memory://` and `redis://` backends);
+  `internal/stage`: cache-entry lifecycle states.
 - `cmd/sqs-echo`, `cmd/sqs-send`: helper CLIs. `cmd/daemon-demo`: shell
   scripts only (demo for daemon/log rotation; no Go code).
-- `awsutil/`: credential loading (platform-split `aws_windows.go` /
-  `aws_others.go`).
-- The root `.norelease` file excludes the legacy v1 binary from CI release
-  builds; CI releases every other `main` package.
+- `doc/v1.md`: docs for the removed legacy v1; do not resurrect v1 code.
+- CI releases every `main` package (root `sqs-notify`, `sqs-echo`,
+  `sqs-send`); drop a `.norelease` file in a package dir to opt it out.
 
 ## Commands
 
-- `make build` — `go build ./...`
-- `make test` — `go test ./...`
-- Single test: `go test ./sqsnotify2/ -run TestName`
-- `make checkall` — `go vet` + `staticcheck` (requires `staticcheck` binary;
-  `staticcheck.conf` enables all checks)
+- `make build` — `go build -gcflags '-e' ./...`
+- `make test` — `go test ./...` (`make race` adds `-race`)
+- Single test: `go test ./internal/sqsnotify/ -run TestName`
+- `make checkall` — `go vet` + `staticcheck` (requires the `staticcheck`
+  binary; `staticcheck.conf` enables all checks)
 - CI (`.github/workflows/go.yml`, on push, multi-OS): only runs
   `go test ./...` plus release builds. No lint in CI.
 
 ## Tests
 
-- No external services needed: `sqsnotify2` tests spin up a local GoAWS mock
-  SQS server (`servertest`) on `127.0.0.1:0` with mock AWS credentials.
-- Redis cache tests in `sqsnotify2/cache_test.go` skip unless `REDIS_URL` is set.
+- No external services needed: `internal/sqsnotify` tests spin up a local
+  GoAWS mock SQS server (`servertest`) on `127.0.0.1:0` with mock AWS
+  credentials set inside the tests; `internal/cache` redis tests use
+  miniredis.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $ go install github.com/koron/sqs-notify/v2@latest
 From online help.
 
 ```
+  -auto-extend
+    	enables automatic message visibility extension
+  -auto-extend-factor value
+    	multiplier for extending the visibility timeout exponentially (default 2)
+  -auto-extend-max value
+    	maximum visibility timeout allowed for a single extension call (default 1h4m0s)
   -cache string
     	cache name or connection URL
     	 * memory://?capacity=1000
@@ -44,6 +50,10 @@ From online help.
     	create queue if not exists
   -endpoint string
     	Endpoint of SQS
+  -grace-period-cleanup value
+    	grace period required for cancellation processing (default 30s)
+  -grace-period-command value
+    	grace period before cancelling the command (default 10s)
   -logfile string
     	log file path
   -max-retries int
@@ -69,8 +79,8 @@ From online help.
     	show version
   -wait-time-seconds int
     	wait time in seconds for next polling. (default -1, disabled, use queue default) (default -1)
-  -workers int
-    	num of workers (default 16)
+  -workers value
+    	num of workers (default 4)
 ```
 
 ## Guide
@@ -112,16 +122,10 @@ Basic usage:
     $ sqs-notify -region ap-northeast-1 -queue my_queue cat
     ```
 
-### Name of regions
+### AWS Regions
 
-*   `us-east-1` (default)
-*   `us-west-1`
-*   `us-west-2`
-*   `eu-west-1`
-*   `ap-southeast-1`
-*   `ap-southeast-2`
-*   `ap-northeast-1`
-*   `sp-east-1`
+The default is `us-east-1`.  For details on AWS Regions, please check
+<https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html>.
 
 ### Logging
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,3 +1,4 @@
+// Package cache provides message cache with memory and redis backends.
 package cache
 
 import (

--- a/internal/sqsnotify/sqsnotify.go
+++ b/internal/sqsnotify/sqsnotify.go
@@ -1,4 +1,4 @@
-// Package sqsnotify provides sqs-notify2 core feature.
+// Package sqsnotify provides sqs-notify core feature.
 package sqsnotify
 
 import (


### PR DESCRIPTION
## Summary
Prepares for the v2.3.0 release by updating `AGENTS.md`, synchronizing `README.md` flags, and adjusting the release workflow for v2 module paths.

## Key Changes
- **AGENTS.md**: Updated layout, commands, and miniredis test details for v2.
- **README.md**: Documented auto-extend & grace-period flags, and updated default worker count.
- **CI Workflows**: Adjusted binary naming logic in `go.yml` to handle major version directory suffixes (e.g. `v2`) properly, and enabled root binary release.
- **Code Cleanups**: Fixed package comments in `internal/cache` and `internal/sqsnotify`.